### PR TITLE
fix: Correct test range completion logic

### DIFF
--- a/BlueProx/ViewControllers/TestViewControllers/StructuredTestViewController.swift
+++ b/BlueProx/ViewControllers/TestViewControllers/StructuredTestViewController.swift
@@ -254,7 +254,8 @@ class StructuredTestViewController: UIViewController, RunCompleteDelegate, MFMai
   
   func updateLoopCountLabel() {
     let numStations = scenarioSelected.selfLocations!.count
-    let currentStation = Int(ceil(Double((currentLoop)/numStations))) + 1
+    let numStepsPerStation = scenarioSelected.subjectAngles!.count
+    let currentStation = Int(ceil(Double((currentLoop)/numStepsPerStation))) + 1
     stationNumberLabel.text = currentStation.description + " / " + numStations.description
   }
   

--- a/BlueProx/ViewControllers/TestViewControllers/StructuredTestViewController.swift
+++ b/BlueProx/ViewControllers/TestViewControllers/StructuredTestViewController.swift
@@ -555,7 +555,7 @@ class StructuredTestViewController: UIViewController, RunCompleteDelegate, MFMai
     }
     
     // NOTE: assumes only one beacon location
-    let numRanges = scenarioSelected.selfLocations!.count
+    let numRanges = scenarioSelected.subjectAngles!.count
     if (currentLoop % numRanges) == 0 {
       isRangeDone = true
     }


### PR DESCRIPTION
When running the Structured - Test Protocol Mid test workflow, the phone begins the 6ft 0° test at the end of the first "station" resulting in that data being captured in the log file. This was as a result of the logic using the number of locations, rather than the number of angles when determining if the test range had been completed or not. All of the other test workflows perform correctly because the number of angles and locations are the same.